### PR TITLE
Use a constant-time hash comparison when validating token checksums

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,5 @@
 install-test-deps:
 	cd tests && npm install
+
+test:
+	vendor/bin/phpunit

--- a/src/Token.php
+++ b/src/Token.php
@@ -111,7 +111,7 @@ final class Token
             generate_key($this->password, $salt)
         );
 
-        if ($actualChecksum !== $expectedChecksum) {
+        if (!hash_equals($expectedChecksum, $actualChecksum)) {
             throw new InvalidTokenException('Invalid checksum.');
         }
     }

--- a/src/functions.php
+++ b/src/functions.php
@@ -115,3 +115,22 @@ function normalize_password($password)
     throw new Iae('Passwords must be strings or instances of'
         . ' Jsq\\Iron\\PasswordInterface');
 }
+
+function hash_equals($expected, $actual)
+{
+    if (function_exists('hash_equals')) {
+        return \hash_equals($expected, $actual);
+    }
+
+    if (strlen($expected) !== strlen($actual)) {
+        return false;
+    }
+
+    $result = $expected ^ $actual;
+    $return = 0;
+    for ($i = 0; $i < strlen($result); $i++) {
+        $return |= ord($result{$i});
+    }
+
+    return !$return;
+}


### PR DESCRIPTION
Resolves #3 
